### PR TITLE
[+] Allow `respondWith` to accept headers

### DIFF
--- a/mock-fetch-api.js
+++ b/mock-fetch-api.js
@@ -33,6 +33,15 @@ global.fetch = function(uri, options) {
       headers: null,
    }, options || {});
 
+   if (uri instanceof Request) {
+        options = uri;
+        uri = uri.url;
+
+        if (!options.method) {
+            options.method = 'GET'
+        }
+    }
+   
    return new Promise(function(resolve, reject) {
 
       if(failNextCall) {

--- a/mock-fetch-api.js
+++ b/mock-fetch-api.js
@@ -73,7 +73,8 @@ global.fetch = function(uri, options) {
             }
 
             return resolve(new Response(criteria.response.jsonData, {
-               status: criteria.response.status
+               status: criteria.response.status,
+               headers: criteria.headers
             }));
 
          }
@@ -125,11 +126,12 @@ module.exports = {
          },
 
 
-         respondWith: function(status, data) {
+         respondWith: function(status, data, headers) {
 
             condition.response = {
                status: status,
-               jsonData: data
+               jsonData: data,
+               headers: headers
             };
 
             conditions.push(condition);


### PR DESCRIPTION
Sometimes your code or the env you are testing in depend on headers for correct functioning.
In my case I __have to__ get back `application/json` as `Content-Type` or my data won't be parsed and all my tests would fail.